### PR TITLE
Update requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ absl-py==2.0.0
 aioice==0.9.0
 aiortc==1.8.0
 anyio==4.0.0
-arandr==0.1.11
 argon2-cffi==23.1.0
 argon2-cffi-bindings==21.2.0
 arrow==1.3.0
@@ -11,7 +10,7 @@ astroid==2.14.2
 asttokens==2.2.1
 async-lru==2.0.4
 attrs==23.1.0
-av==10.0.0
+av==11.0.0
 Babel==2.10.3
 beautifulsoup4==4.11.2
 bidict==0.22.1
@@ -29,6 +28,7 @@ contourpy==1.2.0
 cryptography==42.0.5
 cupshelpers==1.0
 cycler==0.12.1
+depthai==3.1.0
 dbus-python==1.3.2
 debugpy==1.8.0
 decorator==5.1.1
@@ -347,4 +347,3 @@ widgetsnbextension==4.0.9
 wrapt==1.14.1
 wsproto==1.2.0
 zipp==1.0.0
-depthai


### PR DESCRIPTION
- Remove arandr. Use arandr from distribution package.
- Update av to version 11.0.0.
- Fix depthai to version 3.1.0.

Fixes #12, fixes #14 and fixes #18.